### PR TITLE
Refacto/kafka config partner

### DIFF
--- a/src/main/java/fr/formationacademy/scpiinvestpluspartner/configuration/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/fr/formationacademy/scpiinvestpluspartner/configuration/kafka/KafkaConsumerConfig.java
@@ -1,6 +1,7 @@
 package fr.formationacademy.scpiinvestpluspartner.configuration.kafka;
 
 import fr.formationacademy.scpiinvestpluspartner.dto.ScpiRequestDto;
+import fr.formationacademy.scpiinvestpluspartner.utils.TopicNameProvider;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,16 +27,18 @@ public class KafkaConsumerConfig {
     public String bootstrapServers;
 
     private final KafkaTemplate<Object, Object> kafkaTemplate;
+    private final TopicNameProvider topicNameProvider;
 
-    public KafkaConsumerConfig(KafkaTemplate<Object, Object> kafkaTemplate) {
+    public KafkaConsumerConfig(KafkaTemplate<Object, Object> kafkaTemplate, TopicNameProvider topicNameProvider) {
         this.kafkaTemplate = kafkaTemplate;
+        this.topicNameProvider = topicNameProvider;
     }
 
     @Bean
     public ConsumerFactory<String, ScpiRequestDto> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, SCPI_PARTNER_GROUP);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, topicNameProvider.getGroupTopic());
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "fr.formationacademy.scpiinvestpluspartner.dto");

--- a/src/main/java/fr/formationacademy/scpiinvestpluspartner/listener/InvestmentRequestListener.java
+++ b/src/main/java/fr/formationacademy/scpiinvestpluspartner/listener/InvestmentRequestListener.java
@@ -3,6 +3,7 @@ package fr.formationacademy.scpiinvestpluspartner.listener;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.formationacademy.scpiinvestpluspartner.dto.ScpiRequestDto;
 import fr.formationacademy.scpiinvestpluspartner.service.ProcessInvestmentService;
+import fr.formationacademy.scpiinvestpluspartner.utils.TopicNameProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -14,13 +15,16 @@ import static fr.formationacademy.scpiinvestpluspartner.utils.Constants.SCPI_REQ
 @Slf4j
 public class InvestmentRequestListener {
     private final ProcessInvestmentService processInvestmentService;
-
-    public InvestmentRequestListener(ProcessInvestmentService processInvestmentService) {
+    private final TopicNameProvider topicNameProvider;
+    private final String scpiInvestRequestTopic;
+    public InvestmentRequestListener(ProcessInvestmentService processInvestmentService, TopicNameProvider topicNameProvider) {
         this.processInvestmentService = processInvestmentService;
+        this.topicNameProvider = topicNameProvider;
+        this.scpiInvestRequestTopic = topicNameProvider.getScpiInvestRequestTopic();
     }
 
     @KafkaListener(
-            topics = SCPI_REQUEST_TOPIC,
+            topics = "#{topicNameProvider.getScpiInvestRequestTopic()}",
             groupId = SCPI_PARTNER_GROUP
     )
     public void investmentRequestListener(String message) {

--- a/src/main/java/fr/formationacademy/scpiinvestpluspartner/service/InvestmentService.java
+++ b/src/main/java/fr/formationacademy/scpiinvestpluspartner/service/InvestmentService.java
@@ -7,6 +7,7 @@ import fr.formationacademy.scpiinvestpluspartner.enums.InvestmentState;
 import fr.formationacademy.scpiinvestpluspartner.feign.NotificationClient;
 import fr.formationacademy.scpiinvestpluspartner.repository.InvestmentRepository;
 import fr.formationacademy.scpiinvestpluspartner.repository.ScpiRepository;
+import fr.formationacademy.scpiinvestpluspartner.utils.TopicNameProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
@@ -28,13 +29,17 @@ public class InvestmentService {
     private final TemplateEngine templateEngine;
     private final NotificationClient notificationClient;
     private final ScpiRepository scpiRepository;
+    private final TopicNameProvider topicNameProvider;
 
-    public InvestmentService(InvestmentRepository investmentRepository, KafkaTemplate<String, Object> kafkaTemplate, TemplateEngine templateEngine, NotificationClient notificationClient, ScpiRepository scpiRepository) {
+    public InvestmentService(InvestmentRepository investmentRepository, KafkaTemplate<String, Object> kafkaTemplate,
+                             TemplateEngine templateEngine, NotificationClient notificationClient,
+                             ScpiRepository scpiRepository, TopicNameProvider topicNameProvider) {
         this.investmentRepository = investmentRepository;
         this.kafkaTemplate = kafkaTemplate;
         this.templateEngine = templateEngine;
         this.notificationClient = notificationClient;
         this.scpiRepository = scpiRepository;
+        this.topicNameProvider = topicNameProvider;
     }
 
     public void updateInvestmentStatus(Integer id, InvestmentState status, String rejectReason) {
@@ -48,13 +53,13 @@ public class InvestmentService {
                     () -> new IllegalStateException("SCPI " + investment.getScpiName() + "  not found in the database ")
             );
 
-            log.info("SCpi chargée :  {} ", scpi);
+            log.info("LOADED SCPI :  {} ", scpi);
             InvestmentResponse response = InvestmentResponse.builder()
                     .investmentId(id)
                     .investmentState(status)
                     .rejectionReason(rejectReason).build();
 
-            kafkaTemplate.send(SCPI_PARTNER_RESPONSE_TOPIC, response);
+            kafkaTemplate.send(topicNameProvider.getScpiInvestPartnerResponseTopic(), response);
 
             Context context = new Context();
             if (status == ACCEPTED) {
@@ -88,12 +93,15 @@ public class InvestmentService {
                 log.error(e.getMessage());
                 log.info("Error sending notification");
             }
-            investment.setInvestmentState(PENDING_PAYMENT);
-            investmentRepository.save(investment);
 
-            response.setInvestmentState(PENDING_PAYMENT);
-            kafkaTemplate.send(SCPI_PARTNER_RESPONSE_TOPIC, response);
-            log.info("L'investissement est passé en mode : Pendign payement : {}", investment);
+            if(status == ACCEPTED) {
+                investment.setInvestmentState(PENDING_PAYMENT);
+                log.info("[updateInvestmentStatus] ADD the investment in mongon as PENDING_PAYMENT state ");
+                investmentRepository.save(investment);
+                response.setInvestmentState(PENDING_PAYMENT);
+                kafkaTemplate.send(topicNameProvider.getScpiInvestPartnerResponseTopic(), response); // PARTNER RESPONSE
+                log.info("[updateInvestmentStatus]  L'investissement est passé en mode : Pendign payement : {}", investment);
+            }
 
 
         });
@@ -102,15 +110,17 @@ public class InvestmentService {
     }
 
     public void proceedForPayment(Integer label, BigDecimal amount, String iban, String bic) {
+        log.info("[proceedForPayment] L'investissement numero {} est en cours de validation de payement", label);
         investmentRepository.findById(label).ifPresent(investment -> {
             investment.setInvestmentState(VALIDATED);
             investmentRepository.save(investment);
-
+            log.info("[proceedForPayment] L'invsitissement a été payé, voici son etat actuel {} ", investment);
             InvestmentResponse response = InvestmentResponse.builder()
                     .investmentId(label)
                     .investmentState(VALIDATED)
                     .build();
-            kafkaTemplate.send(SCPI_PARTNER_RESPONSE_TOPIC, response);
+            log.info("[proceedForPayment] Réponse du partener vers api {}", response);
+            kafkaTemplate.send(topicNameProvider.getScpiInvestPartnerResponseTopic(), response);
         });
     }
 }

--- a/src/main/java/fr/formationacademy/scpiinvestpluspartner/utils/Constants.java
+++ b/src/main/java/fr/formationacademy/scpiinvestpluspartner/utils/Constants.java
@@ -2,7 +2,7 @@ package fr.formationacademy.scpiinvestpluspartner.utils;
 
 public interface Constants {
     //KAFKA
-    String SCPI_PARTNER_GROUP = "scpi-partner-group";
-    String SCPI_REQUEST_TOPIC = "scpi-request-partner";
-    String SCPI_PARTNER_RESPONSE_TOPIC = "scpi-partner-response-topic";
+    String SCPI_PARTNER_GROUP = "scpi-invest-partner-group";
+    String SCPI_REQUEST_TOPIC = "scpi-invest-partner-request-topic";
+    String SCPI_PARTNER_RESPONSE_TOPIC = "scpi-invest-partner-response-topic";
 }

--- a/src/main/java/fr/formationacademy/scpiinvestpluspartner/utils/TopicNameProvider.java
+++ b/src/main/java/fr/formationacademy/scpiinvestpluspartner/utils/TopicNameProvider.java
@@ -1,0 +1,38 @@
+package fr.formationacademy.scpiinvestpluspartner.utils;
+
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import static fr.formationacademy.scpiinvestpluspartner.utils.Constants.*;
+
+
+@Component
+public class TopicNameProvider {
+    private final String groupTopic;
+    private String scpiInvestRequestTopic;
+    private String scpiInvestPartnerResponseTopic;
+
+    public TopicNameProvider(Environment environment) {
+        String activeProfile = getActiveProfile(environment);
+        this.scpiInvestRequestTopic = SCPI_REQUEST_TOPIC + "-" + activeProfile;
+        this.scpiInvestPartnerResponseTopic = SCPI_PARTNER_RESPONSE_TOPIC + "-" + activeProfile;
+        this.groupTopic = SCPI_PARTNER_GROUP + "-" + activeProfile;
+    }
+
+    private String getActiveProfile(Environment environment) {
+        String[] profiles = environment.getActiveProfiles();
+        return profiles.length > 0 ? profiles[0] : "UNDEFINED";
+    }
+
+    public String getScpiInvestRequestTopic() {
+        return scpiInvestRequestTopic;
+    }
+
+    public String getScpiInvestPartnerResponseTopic() {
+        return scpiInvestPartnerResponseTopic;
+    }
+
+    public String getGroupTopic() {
+        return groupTopic;
+    }
+}


### PR DESCRIPTION
**UPDATES**:

1. Update Kafka Topic Configuration:
  - Create a topic for each profile (local, default).
  - Create a group ID for each profile to avoid consumption issues.

2. Handle service notification exceptions during the sending of emails.